### PR TITLE
Redirect EBF 1.5 to look for this variant of Quality Bionics

### DIFF
--- a/Source/QualityBionicsRemastered/Patch/EBF_BackCompatRedirect_ModDetector.cs
+++ b/Source/QualityBionicsRemastered/Patch/EBF_BackCompatRedirect_ModDetector.cs
@@ -1,0 +1,35 @@
+﻿using HarmonyLib;
+using System.Linq;
+using System.Reflection;
+using Verse;
+
+namespace QualityBionicsRemastered.Patch
+{
+    /// <summary>
+    /// EBF 1.5 is looking specifically for the ilyvion variant.
+    /// If we are sure to welcome these 1.5 users, then EBF 1.5 needs to be patched to look for this variant instead.
+    /// <para/>
+    /// EBF 1.6+ will not trigger this patch since we would be using the EBF "receptor" API for compatibility.
+    /// </summary>
+    [HarmonyPatch]
+    public static class EBF_BackCompatRedirect_ModDetector
+    {
+        public static bool Prepare()
+        {
+            return TargetMethod() != null;
+        }
+
+        public static MethodBase TargetMethod()
+        {
+            return AccessTools.PropertyGetter("EBF.Util.ModDetector:QualityBionicsContinuedIsLoaded"); ;
+        }
+
+        [HarmonyPrefix]
+        public static bool DetectThisQualityBionicsVersionCorrectly(ref bool __result)
+        {
+            // redirect 1.5 EBF to look for this mod instead
+            __result = LoadedModManager.RunningMods.Any((ModContentPack pack) => pack.Name.Contains("Quality Bionics") && pack.PackageId.Contains("assassinsbro"));
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This continues from #5.

#5 made it such that 1.5 users' bionics no longer disappear due to "class not found" errors, but then 1.5 users' bionics would not have EBF effect since EBF 1.5 is looking specifically for the old variant. This was first mentioned in https://github.com/WimStienstra/Quality-Bionics-Remastered/pull/3#issuecomment-3193583053.

Content as titled. This should finally restore full EBF 1.5 compatibility.

This has been a very intense weekend.